### PR TITLE
feat: Improve auto routing logic in main layout

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -24,23 +24,23 @@
 			updateAuthStore(authStore, user);
 
 			currentPath = window.location.pathname;
-			if (!user && !noAuthRoutes.includes(currentPath)) {
+			const isPublicRoute = noAuthRoutes.includes(currentPath);
+
+			if (!user && !isPublicRoute) {
 				// Unauthenticated user wants to go to a protected route
 				goto('/login');
 				return;
-			} else if (!user && noAuthRoutes.includes(currentPath)) {
+			} else if (!user && isPublicRoute) {
 				// Unauthenticated user wants to go to a public route
 				goto(currentPath);
 				return;
-			} else if (user && noAuthRoutes.includes(currentPath)) {
+			} else if (user && isPublicRoute) {
 				// Authenticated user wants to go to a public route
 				goto('/dashboard');
 				return;
-			} else if (user && !noAuthRoutes.includes(currentPath)) {
-				// Authenticated user wants to go to a public route
+			} else if (user && !isPublicRoute) {
+				// Authenticated user wants to go to a private route
 				goto(currentPath);
-				return;
-			} else {
 				return;
 			}
 		});

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -28,15 +28,19 @@
 				// Unauthenticated user wants to go to a protected route
 				goto('/login');
 				return;
-			}
-			if (!user && noAuthRoutes.includes(currentPath)) {
+			} else if (!user && noAuthRoutes.includes(currentPath)) {
 				// Unauthenticated user wants to go to a public route
 				goto(currentPath);
 				return;
-			}
-			if (user) {
-				// Authenticated user
+			} else if (user && noAuthRoutes.includes(currentPath)) {
+				// Authenticated user wants to go to a public route
+				goto('/dashboard');
+				return;
+			} else if (user && !noAuthRoutes.includes(currentPath)) {
+				// Authenticated user wants to go to a public route
 				goto(currentPath);
+				return;
+			} else {
 				return;
 			}
 		});


### PR DESCRIPTION
## Description

This small PR improves the rerouting logic by preventing authenticated users to visit non authenticated routes, such as login and signup. In such scenarios, users are automatically directed to dashboard route. 

## Task

[Notion Task Link](https://www.notion.so/d077118807034bbfb517f36c20d2a304?v=345833d9689145a2b5a197646677c93e&p=080bcc3c55c242f58c32672ef8a560e8&pm=s)

## Screenshots (optional)
