### PR TITLE
Feat: fetch tricks from firestore

### DIFF
--- a/src/lib/handlers/db.js
+++ b/src/lib/handlers/db.js
@@ -5,16 +5,10 @@ export const getUserTricks = async (user) => {
 	if (!user) return [];
 	const userRef = doc(db, 'users', user.uid);
 	const userSnap = await getDoc(userRef);
+
 	if (!userSnap.exists()) {
 		console.log('No data for this user found in the collection.');
-		const newUser = doc(db, 'users', user.uid);
-		await setDoc(
-			newUser,
-			{
-				email: user.email
-			},
-			{ merge: true }
-		);
+		await createUserDocument(user);
 	}
 	const tricksCollection = collection(userRef, 'tricks');
 	// Get tricks in the collection
@@ -25,4 +19,17 @@ export const getUserTricks = async (user) => {
 		formattedTricks.push({ ...doc.data(), id: doc.id });
 	});
 	return formattedTricks;
+};
+
+const createUserDocument = async (user) => {
+	const newUser = doc(db, 'users', user.uid);
+	await setDoc(
+		newUser,
+		{
+			email: user.email
+		},
+		{ merge: true }
+	);
+	console.log('User created');
+	return;
 };

--- a/src/lib/handlers/db.js
+++ b/src/lib/handlers/db.js
@@ -1,0 +1,28 @@
+import { db } from '$lib/firebase/firebase';
+import { collection, doc, getDoc, getDocs, setDoc } from 'firebase/firestore';
+
+export const getUserTricks = async (user) => {
+	if (!user) return [];
+	const userRef = doc(db, 'users', user.uid);
+	const userSnap = await getDoc(userRef);
+	if (!userSnap.exists()) {
+		console.log('No data for this user found in the collection.');
+		const newUser = doc(db, 'users', user.uid);
+		await setDoc(
+			newUser,
+			{
+				email: user.email
+			},
+			{ merge: true }
+		);
+	}
+	const tricksCollection = collection(userRef, 'tricks');
+	// Get tricks in the collection
+	const userTricks = await getDocs(tricksCollection);
+
+	let formattedTricks = [];
+	userTricks.forEach((doc) => {
+		formattedTricks.push({ ...doc.data(), id: doc.id });
+	});
+	return formattedTricks;
+};

--- a/src/lib/store/store.js
+++ b/src/lib/store/store.js
@@ -2,5 +2,6 @@ import { writable } from 'svelte/store';
 
 export const authStore = writable({
 	user: null,
-	loading: true
+	loading: true,
+	tricks: []
 });

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -8,12 +8,13 @@
 	const noAuthRoutes = ['/', '/login', '/signup'];
 	let currentPath;
 
-	const updateAuthStore = (authStore, user) => {
+	const updateAuthStore = (authStore, user, userTricks) => {
 		authStore.update((curr) => {
 			return {
 				...curr,
 				user: user?.email || null,
-				loading: false
+				loading: false,
+				tricks: userTricks
 			};
 		});
 	};

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,10 +1,10 @@
 <script>
 	import '../app.postcss';
-	import { auth, db } from '../lib/firebase/firebase';
+	import { auth } from '../lib/firebase/firebase';
 	import { authStore } from '$lib/store/store';
 	import { onMount } from 'svelte';
 	import { goto } from '$app/navigation';
-	import { collection, doc, getDoc, getDocs, setDoc } from 'firebase/firestore';
+	import { getUserTricks } from '$lib/handlers/db.js';
 	import Navbar from '$components/Navbar.svelte';
 	const noAuthRoutes = ['/', '/login', '/signup'];
 	let currentPath;
@@ -28,31 +28,6 @@
 		});
 	});
 
-	const getUserTricks = async (user) => {
-		if (!user) return [];
-		const userRef = doc(db, 'users', user.uid);
-		const userSnap = await getDoc(userRef);
-		if (!userSnap.exists()) {
-			console.log('No data for this user found in the collection.');
-			const newUser = doc(db, 'users', user.uid);
-			await setDoc(
-				newUser,
-				{
-					email: user.email
-				},
-				{ merge: true }
-			);
-		}
-		const tricksCollection = collection(userRef, 'tricks');
-		// Get tricks in the collection
-		const userTricks = await getDocs(tricksCollection);
-
-		let formattedTricks = [];
-		userTricks.forEach((doc) => {
-			formattedTricks.push({ ...doc.data(), id: doc.id });
-		});
-		return formattedTricks;
-	};
 	const redirectUser = (user) => {
 		currentPath = window.location.pathname;
 		const isPublicRoute = noAuthRoutes.includes(currentPath);

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -22,30 +22,9 @@
 
 	onMount(() => {
 		const unsubscribe = auth.onAuthStateChanged(async (user) => {
-			
-			let userTricks = await getUserTricks(user)
+			let userTricks = await getUserTricks(user);
 			updateAuthStore(authStore, user, userTricks);
-
-			currentPath = window.location.pathname;
-			const isPublicRoute = noAuthRoutes.includes(currentPath);
-
-			if (!user && !isPublicRoute) {
-				// Unauthenticated user wants to go to a protected route
-				goto('/login');
-				return;
-			} else if (!user && isPublicRoute) {
-				// Unauthenticated user wants to go to a public route
-				goto(currentPath);
-				return;
-			} else if (user && isPublicRoute) {
-				// Authenticated user wants to go to a public route
-				goto('/gallery');
-				return;
-			} else if (user && !isPublicRoute) {
-				// Authenticated user wants to go to a private route
-				goto(currentPath);
-				return;
-			}
+			redirectUser(user);
 		});
 	});
 
@@ -73,6 +52,27 @@
 			formattedTricks.push({ ...doc.data(), id: doc.id });
 		});
 		return formattedTricks;
+	};
+	const redirectUser = (user) => {
+		currentPath = window.location.pathname;
+		const isPublicRoute = noAuthRoutes.includes(currentPath);
+		if (!user && !isPublicRoute) {
+			// Unauthenticated user wants to go to a protected route
+			goto('/login');
+			return;
+		} else if (!user && isPublicRoute) {
+			// Unauthenticated user wants to go to a public route
+			goto(currentPath);
+			return;
+		} else if (user && isPublicRoute) {
+			// Authenticated user wants to go to a public route
+			goto('/gallery');
+			return;
+		} else if (user && !isPublicRoute) {
+			// Authenticated user wants to go to a private route
+			goto(currentPath);
+			return;
+		}
 	};
 </script>
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,9 +1,10 @@
 <script>
 	import '../app.postcss';
-	import { auth } from '../lib/firebase/firebase';
+	import { auth, db } from '../lib/firebase/firebase';
 	import { authStore } from '$lib/store/store';
 	import { onMount } from 'svelte';
 	import { goto } from '$app/navigation';
+	import { collection, doc, getDoc, getDocs, setDoc } from 'firebase/firestore';
 	import Navbar from '$components/Navbar.svelte';
 	const noAuthRoutes = ['/', '/login', '/signup'];
 	let currentPath;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -28,6 +28,19 @@
 			const userRef = doc(db, 'users', user.uid);
 			const userSnap = await getDoc(userRef);
 
+			// Check if a user document exists in firestore
+			if (!userSnap.exists()) {
+				// No data in the db. Create a user document in users collection
+				const newUser = doc(db, 'users', user.uid);
+				await setDoc(
+					newUser,
+					{
+						email: user.email
+					},
+					{ merge: true }
+				);
+			}
+
 			currentPath = window.location.pathname;
 			const isPublicRoute = noAuthRoutes.includes(currentPath);
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -45,6 +45,10 @@
 			// Get tricks in the collection
 			const userTricks = await getDocs(tricksCollection);
 
+			let formattedTricks = [];
+			userTricks.forEach((doc) => {
+				formattedTricks.push({ ...doc.data(), id: doc.id });
+			});
 
 			currentPath = window.location.pathname;
 			const isPublicRoute = noAuthRoutes.includes(currentPath);

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -42,6 +42,9 @@
 			}
 
 			const tricksCollection = collection(userRef, 'tricks');
+			// Get tricks in the collection
+			const userTricks = await getDocs(tricksCollection);
+
 
 			currentPath = window.location.pathname;
 			const isPublicRoute = noAuthRoutes.includes(currentPath);

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -22,7 +22,6 @@
 	onMount(() => {
 		const unsubscribe = auth.onAuthStateChanged(async (user) => {
 			//Update the auth store with new user data
-			updateAuthStore(authStore, user);
 
 			// Access user data in Firestore
 			if (!user) return;
@@ -50,9 +49,12 @@
 			userTricks.forEach((doc) => {
 				formattedTricks.push({ ...doc.data(), id: doc.id });
 			});
+			updateAuthStore(authStore, user, formattedTricks);
 
 			currentPath = window.location.pathname;
 			const isPublicRoute = noAuthRoutes.includes(currentPath);
+
+
 
 			if (!user && !isPublicRoute) {
 				// Unauthenticated user wants to go to a protected route

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -41,6 +41,8 @@
 				);
 			}
 
+			const tricksCollection = collection(userRef, 'tricks');
+
 			currentPath = window.location.pathname;
 			const isPublicRoute = noAuthRoutes.includes(currentPath);
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -23,6 +23,11 @@
 			//Update the auth store with new user data
 			updateAuthStore(authStore, user);
 
+			// Access user data in Firestore
+			if (!user) return;
+			const userRef = doc(db, 'users', user.uid);
+			const userSnap = await getDoc(userRef);
+
 			currentPath = window.location.pathname;
 			const isPublicRoute = noAuthRoutes.includes(currentPath);
 

--- a/src/routes/gallery/+page.svelte
+++ b/src/routes/gallery/+page.svelte
@@ -1,10 +1,11 @@
 <script>
 	import Card from '$components/Card.svelte';
 	import { authStore } from '$lib/store/store';
+	import Spinner from '$components/Spinner.svelte'
 </script>
 
 {#if $authStore.loading}
-	<p>Loading</p>
+ <Spinner/>
 {:else}
 	<section class="grid p-4 gap-4 lg:grid-cols-6 md:grid-cols-4 grid-cols-2">
 		{#each $authStore.tricks as trick}

--- a/src/routes/gallery/+page.svelte
+++ b/src/routes/gallery/+page.svelte
@@ -1,7 +1,7 @@
 <script>
 	import Card from '$components/Card.svelte';
 	import { authStore } from '$lib/store/store';
-	
+
 	const tricks = Array.from({ length: 20 }).map((_, i) => {
 		const id = i + 1;
 		return {
@@ -15,7 +15,7 @@
 </script>
 
 <section class="grid p-4 gap-4 lg:grid-cols-6 md:grid-cols-4 grid-cols-2">
-	{#each tricks as trick}
+	{#each $authStore.tricks as trick}
 		<Card {trick} />
 	{/each}
 </section>

--- a/src/routes/gallery/+page.svelte
+++ b/src/routes/gallery/+page.svelte
@@ -1,11 +1,11 @@
 <script>
 	import Card from '$components/Card.svelte';
 	import { authStore } from '$lib/store/store';
-	import Spinner from '$components/Spinner.svelte'
+	import Spinner from '$components/Spinner.svelte';
 </script>
 
 {#if $authStore.loading}
- <Spinner/>
+	<Spinner />
 {:else}
 	<section class="grid p-4 gap-4 lg:grid-cols-6 md:grid-cols-4 grid-cols-2">
 		{#each $authStore.tricks as trick}

--- a/src/routes/gallery/+page.svelte
+++ b/src/routes/gallery/+page.svelte
@@ -1,17 +1,6 @@
 <script>
 	import Card from '$components/Card.svelte';
 	import { authStore } from '$lib/store/store';
-
-	const tricks = Array.from({ length: 20 }).map((_, i) => {
-		const id = i + 1;
-		return {
-			id,
-			title: `Trick ${id}`,
-			standing: id % 2 === 0,
-			minutes: Math.floor(Math.random() * 19) + 1,
-			mix: id % 3 === 0 ? 'regular' : 'tricked'
-		};
-	});
 </script>
 
 <section class="grid p-4 gap-4 lg:grid-cols-6 md:grid-cols-4 grid-cols-2">

--- a/src/routes/gallery/+page.svelte
+++ b/src/routes/gallery/+page.svelte
@@ -1,6 +1,7 @@
 <script>
 	import Card from '$components/Card.svelte';
-
+	import { authStore } from '$lib/store/store';
+	
 	const tricks = Array.from({ length: 20 }).map((_, i) => {
 		const id = i + 1;
 		return {

--- a/src/routes/gallery/+page.svelte
+++ b/src/routes/gallery/+page.svelte
@@ -3,8 +3,12 @@
 	import { authStore } from '$lib/store/store';
 </script>
 
-<section class="grid p-4 gap-4 lg:grid-cols-6 md:grid-cols-4 grid-cols-2">
-	{#each $authStore.tricks as trick}
-		<Card {trick} />
-	{/each}
-</section>
+{#if $authStore.loading}
+	<p>Loading</p>
+{:else}
+	<section class="grid p-4 gap-4 lg:grid-cols-6 md:grid-cols-4 grid-cols-2">
+		{#each $authStore.tricks as trick}
+			<Card {trick} />
+		{/each}
+	</section>
+{/if}


### PR DESCRIPTION
## Description

Setup Firestore collections and access them on page load. 

Current status:
- We have a users collection, in which every user has a document. (If a user doesn't have a db entry, we automatically create a new one on login)
- In this user document, we have a sub collection called tricks. 
- Currently we only have test data connected to test@test.com account. Until we implement CRUD functions for tricks, you can manually add tricks in Firebase console. I am happy to help if that's needed. In any case, let's do our best to add the CRUD functions soon

## Task

[Notion Task Link ](https://www.notion.so/d077118807034bbfb517f36c20d2a304?v=345833d9689145a2b5a197646677c93e&p=e9863ab223344777b724147fb8461ce8&pm=s)

## Screenshots (optional)
![image](https://github.com/berk245/magic-castle/assets/32645610/c363fc0a-7a3d-4812-9816-64ccd9e4b95d)

